### PR TITLE
Correct Markdown Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,20 @@ The pool is designed to provide state agencies with access to user-centered desi
 
 You can also email our team (adpq@state.ca.gov) to get updates about this initiative. 
 
-###The Benefits:
+### The Benefits:
 * Reduction in solicitation time and administrative costs; and
 * Ability to review vendors’ user-centric design and agile software development competencies prior to solicitation.
 
-###The Process:
+### The Process:
 * The State has released the RFI, Technical Prototypes, and a Q&A to all interested vendors (see above files). 
 
 
-###The Results:
+### The Results:
 See the notification of selection notice sent out on Monday April 17, 2017
 
 The California Department of Technology (CDT) advises all partcipants to review the Key Action Dates, Section A.1 PQVP DS-AD Key Action Dates.  
 
-###[Digital Services - Agile Development Vender Pool Refresh Request for Interest (RFI)](https://github.com/CDTProcurement/adpq/blob/master/RFI%20CDT-ADPQ-0117%20-%20PQVP%20DS-AD%20-%20Final%20%2002.06.17.pdf)
+### [Digital Services - Agile Development Vender Pool Refresh Request for Interest (RFI)](https://github.com/CDTProcurement/adpq/blob/master/RFI%20CDT-ADPQ-0117%20-%20PQVP%20DS-AD%20-%20Final%20%2002.06.17.pdf)
  
-###Vendor Pool Questions & Issues:
+### Vendor Pool Questions & Issues:
 If you have a question or issue please submit a email (adpq@state.ca.gov). With respect to questions or issues, please describe the subject or issue in question and any other information useful in identifying the specific problem or issue stated in your question.
-


### PR DESCRIPTION
Markdown formatting for headline items requires a space between the `#` and the text.